### PR TITLE
Add utils.make_conn_str function

### DIFF
--- a/pedsnetdcc/abstract_transform.py
+++ b/pedsnetdcc/abstract_transform.py
@@ -28,14 +28,13 @@ class Transform(object):
     __metaclass__ = ABCMeta
 
     @classmethod
-    def pre_transform(cls, dburi, search_path):
+    def pre_transform(cls, conn_str):
         """Execute statements required before a transform.
 
         A Transform can override this method to execute prerequisite
         statements for a transform, e.g. creating database functions, etc.
 
-        :param str dburi: URL to access database
-        :param str search_path: PostgreSQL schema search_path
+        :param str conn_str: libpq connection string or URI
         :return: None
         """
         pass

--- a/pedsnetdcc/age_transform_test.py
+++ b/pedsnetdcc/age_transform_test.py
@@ -7,6 +7,7 @@ from sqlalchemy.schema import CreateIndex
 
 from pedsnetdcc.age_transform import AgeTransform
 from pedsnetdcc.transform_test_utils import clean
+from pedsnetdcc.utils import make_conn_str
 
 
 class AgeTest(unittest.TestCase):
@@ -96,16 +97,17 @@ class AgeTest(unittest.TestCase):
                     'Unexpected index encountered: {}'.format(index.name))
 
     def test_pre_transform(self):
-        dburi_var = 'AGE_TRANSFORM_DBURI'
-        search_path_var = 'AGE_TRANSFORM_SEARCH_PATH'
+        dburi_var = 'PEDSNETDCC_AGE_TRANSFORM_DBURI'
+        search_path_var = 'PEDSNETDCC_AGE_TRANSFORM_SEARCH_PATH'
         if (dburi_var not in os.environ and
                 search_path_var not in os.environ):
             self.skipTest(
                 '{} and {} required for testing '
                 'AgeTransform.pre_transform'.format(
                     dburi_var, search_path_var))
-        AgeTransform.pre_transform(os.environ[dburi_var],
-                                   os.environ[search_path_var])
+        conn_str = make_conn_str(url=os.environ[dburi_var],
+                                 search_path=os.environ[search_path_var])
+        AgeTransform.pre_transform(conn_str)
         # TODO: verify function creation via introspection
 
     def test_with_data(self):

--- a/pedsnetdcc/transform_test_utils.py
+++ b/pedsnetdcc/transform_test_utils.py
@@ -1,5 +1,6 @@
 import re
 
+
 def clean(s):
     """Strip leading & trailing space, remove newlines, compress space.
     Also expand '{NL}' to a literal newline.

--- a/pedsnetdcc/utils.py
+++ b/pedsnetdcc/utils.py
@@ -1,0 +1,69 @@
+import urllib.parse
+
+
+def make_conn_str(url, search_path=None, password=None):
+    """Return a libpq-compliant connection string usable with psycopg2.
+
+    If `search_path` is supplied, it is incorporated into the connection string
+    via the `options` parameter, overriding any existing search_path in the
+    `url`.
+
+    If `password` is supplied, it is incorporated into the connection string,
+    overriding any existing password in the `url`.
+
+    Keywords recognized: host, port, dbname, user, password, options.
+
+    Other query parameters are passed as is.
+
+    See https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING
+
+    :param str url:
+    :param str search_path:
+    :param str password:
+    :rtype: str
+    """
+    components = urllib.parse.urlparse(url)
+    params = urllib.parse.parse_qs(components.query)
+    parts = []
+
+    if components.hostname:
+        parts.append('host=' + components.hostname)
+    if components.port:
+        parts.append('port=' + str(components.port))
+    if components.path:
+        parts.append('dbname=' + components.path.lstrip('/'))
+    if components.username:
+        parts.append('user=' + components.username)
+    if password:
+        parts.append('password=' + password)
+    elif components.password:
+        parts.append('password=' + components.password)
+
+    o_dict = {}
+    if 'options' in params:
+        if len(params['options']) > 1:
+            raise ValueError("More than one `options` key words unsupported")
+        options_val = params['options'][0].strip("'")
+        options = [o.strip() for o in options_val.split('-c ')]
+        for option in options:
+            if not option:
+                continue
+            k, v = option.split('=', 1)
+            o_dict[k] = v
+
+    if search_path:
+        o_dict['search_path'] = search_path
+
+    options_value = ' '.join(
+        ["-c {}={}".format(k, o_dict[k]) for k in sorted(o_dict)])
+    if options_value:
+        params['options'] = [options_value]
+
+    for k in sorted(params):
+        values = params[k]
+        for value in values:
+            if ' ' in value:
+                value = "'{}'".format(value)
+            parts.append('{0}={1}'.format(k, value))
+
+    return ' '.join(parts)

--- a/pedsnetdcc/utils_test.py
+++ b/pedsnetdcc/utils_test.py
@@ -1,0 +1,84 @@
+import os
+import unittest
+
+from pedsnetdcc.utils import make_conn_str
+
+
+class ConnTest(unittest.TestCase):
+
+    def test_url_without_query(self):
+        """ Test adding search_path where query parameters do not exist"""
+        url = "postgresql://ahost/adb"
+        cstr = make_conn_str(url, 'testschema')
+        expected = "host=ahost dbname=adb options='-c search_path=testschema'"
+        self.assertEqual(cstr, expected)
+
+    def test_url_with_query_without_options(self):
+        """ Test adding search_path where query parameters exist"""
+        url = "postgresql://auser:apass@ahost:5433/adb?sslmode=disable" \
+              "&connect_timeout=30"
+        cstr = make_conn_str(url, 'testschema')
+        expected = "host=ahost port=5433 dbname=adb user=auser " \
+                   "password=apass connect_timeout=30 options='-c " \
+                   "search_path=testschema' sslmode=disable"
+        self.assertEqual(cstr, expected)
+
+    def test_url_with_query_with_options(self):
+        """Test adding the search_path into a preexisting options value"""
+        url = "postgresql://auser:apass@ahost:5433/adb?sslmode=disable" \
+              "&connect_timeout=30&options='-c geqo=off'"
+        cstr = make_conn_str(url, 'testschema')
+        expected = "host=ahost port=5433 dbname=adb user=auser " \
+                   "password=apass connect_timeout=30 options='-c geqo=off " \
+                   "-c search_path=testschema' sslmode=disable"
+        self.assertEqual(cstr, expected)
+
+    def test_url_with_query_with_options_with_search_path(self):
+        """Test overriding the search_path"""
+        url = "postgresql://auser:apass@ahost:5433/adb?sslmode=disable" \
+              "&connect_timeout=30&options='-c search_path=to_be_overridden'"
+        cstr = make_conn_str(url, 'testschema')
+        expected = "host=ahost port=5433 dbname=adb user=auser " \
+                   "password=apass connect_timeout=30 options='-c " \
+                   "search_path=testschema' sslmode=disable"
+        self.assertEqual(cstr, expected)
+
+    def test_url_with_password(self):
+        """ Test password and no search_path"""
+        url = "postgresql://auser@ahost/adb"
+        cstr = make_conn_str(url, password='apass')
+        expected = "host=ahost dbname=adb user=auser " \
+                   "password=apass"
+        self.assertEqual(cstr, expected)
+
+    def test_url_no_password_no_search_path(self):
+        """ Test with password and no search_path"""
+        url = "postgresql://auser@ahost/adb"
+        cstr = make_conn_str(url)
+        expected = "host=ahost dbname=adb user=auser"
+        self.assertEqual(cstr, expected)
+
+    def test_url_with_query_without_options_password_override(self):
+        """Test overriding the password"""
+        url = "postgresql://auser:apass@ahost:5433/adb?sslmode=disable" \
+              "&connect_timeout=30"
+        cstr = make_conn_str(url, 'testschema', password='newpass')
+        expected = "host=ahost port=5433 dbname=adb user=auser " \
+                   "password=newpass connect_timeout=30 options='-c " \
+                   "search_path=testschema' sslmode=disable"
+        self.assertEqual(cstr, expected)
+
+    def test_custom_url(self):
+        env_var = 'PEDSNETDCC_UTILS_URL'
+        if not os.environ.get(env_var, None):
+            self.skipTest('{} not defined'.format(env_var))
+        else:
+            import psycopg2
+            schema = 'pedsnet_dcc_utils_test_schema'
+            cstr = make_conn_str(os.environ[env_var], schema)
+            with psycopg2.connect(cstr) as conn:
+                with conn.cursor() as cursor:
+                    cursor.execute('show search_path')
+                    row = cursor.fetchone()
+                    self.assertTrue(schema in row[0])
+            conn.close()

--- a/sync_observation_period.py
+++ b/sync_observation_period.py
@@ -1,5 +1,6 @@
 import logging
 import psycopg2
+from pedsnetdcc.utils import make_conn_str
 
 sql_create_date_table = '''
 CREATE TEMP TABLE date_limit
@@ -73,14 +74,10 @@ GROUP BY person_id
 logger = logging.getLogger('pedsnetdcc')
 
 
-def run(dburi, search_path=''):
+def run(conn_str):
 
-    with psycopg2.connect(dburi) as conn:
+    with psycopg2.connect(conn_str) as conn:
         with conn.cursor() as cursor:
-
-            if search_path:
-                # SQL injection vulnerability?
-                cursor.execute('SET search_path TO {0}'.format(search_path))
 
             cursor.execute(sql_create_date_table)
             cursor.execute(sql_fill_null_maxes)
@@ -101,4 +98,4 @@ def run(dburi, search_path=''):
 
 # Test on data local to Aaron's computer.
 if __name__ == '__main__':
-    run('postgresql://localhost/tmp', 'other')
+    run(make_conn_str('postgresql://localhost/tmp', search_path='other'))


### PR DESCRIPTION
`make_conn_str` makes a psycopg2-compatible connection string
from a URI and optional password and search_path.

Also:

* Adapt age_transform.py and sync_observation_period.py to accept
conn_str instead of URI and search_path.

* Make miscellaneous formatting and minor code cleanups.