### PR TITLE
Issue 9 - add/drop indexes 

### DIFF
--- a/pedsnetdcc/indexes.py
+++ b/pedsnetdcc/indexes.py
@@ -1,0 +1,59 @@
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.schema import CreateIndex, DropIndex
+
+from pedsnetdcc import VOCAB_TABLES
+
+def indexes(metadata, transforms, vocabulary=False):
+    """Return list of SQLAlchemy index objects for the transformed metadata.
+
+    Given the stock metadata, for each transform `T` we invoke:
+
+        new_metadata = T.modify_metadata(metadata)
+
+    and at the end, we extract the indexes.
+
+    :param metadata: SQLAlchemy metadata for PEDSnet
+    :type: sqlalchemy.schema.MetaData
+    :param transforms: list of Transform classes
+    :type: list(type)
+    :param vocabulary: whether to return indexes for vocabulary tables or
+    non-vocabulary tables
+    :type: bool
+    :return: list of index objects
+    :rtype: list(sqlalchemy.Index)
+    """
+    for t in transforms:
+        metadata = t.modify_metadata(metadata)
+
+    indexes = []
+    for name, table in metadata.tables.items():
+        if vocabulary:
+            if name in VOCAB_TABLES:
+                indexes.extend(table.indexes)
+        else:
+            if name not in VOCAB_TABLES:
+                indexes.extend(table.indexes)
+
+    return indexes
+
+
+def add_indexes_sql(indexes):
+    """Create generic ADD INDEX statements.
+    :param indexes: list of indexes
+    :type: list(sqlalchemy.Index)
+    :return: list of SQL ADD INDEX statements
+    :type: list(str)
+    """
+    return [str(CreateIndex(x).compile(
+                dialect=postgresql.dialect())) for x in indexes]
+
+
+def drop_indexes_sql(indexes):
+    """Create generic DROP INDEX statements.
+    :param indexes: list of indexes
+    :type: list(sqlalchemy.Index)
+    :return: list of SQL DROP INDEX statements
+    :type: list(str)
+    """
+    return [str(DropIndex(x).compile(
+                dialect=postgresql.dialect())).lstrip() for x in indexes]

--- a/pedsnetdcc/indexes.py
+++ b/pedsnetdcc/indexes.py
@@ -154,8 +154,11 @@ def _process_indexes(conn_str, model_version, force, vocabulary, drop):
         operation = 'removal'
 
     # Log start of the function and set the starting time.
-    logger.info({'msg': 'starting index {op}'.format(op=operation),
-                 'model_version': model_version, 'vocabulary': vocabulary})
+    log_dict = combine_dicts({'model_version': model_version,
+                              'vocabulary': vocabulary, 'force': force},
+                             get_conn_info_dict(conn_str))
+    logger.info(combine_dicts({'msg': 'starting index {op}'.format(
+        op=operation)}, log_dict))
     start_time = time.time()
 
     stmts = StatementSet()
@@ -171,18 +174,19 @@ def _process_indexes(conn_str, model_version, force, vocabulary, drop):
         try:
             _check_stmt_err(stmt, force)
         except Exception:
-            conn_info = get_conn_info_dict(conn_str)
             logger.error(combine_dicts({'msg': 'Fatal error',
-                                        'force': force,
                                         'sql': stmt.sql,
-                                        'err': str(stmt.err)}, conn_info))
-            logger.info({'msg': 'aborted index {op}'.format(op=operation),
-                         'elapsed': secs_since(start_time)})
+                                        'err': str(stmt.err)}, log_dict))
+            logger.info(combine_dicts(
+                {'msg': 'aborted index {op}'.format(op=operation),
+                 'elapsed': secs_since(start_time)},
+                log_dict))
             raise
 
     # Log end of function.
-    logger.info({'msg': 'finished index {op}'.format(op=operation),
-                 'elapsed': secs_since(start_time)})
+    logger.info(combine_dicts(
+        {'msg': 'finished index {op}'.format(op=operation),
+         'elapsed': secs_since(start_time)}, log_dict))
 
     # If reached without error, then success!
     return True
@@ -200,11 +204,11 @@ def add_indexes(conn_str, model_version, force=False, vocabulary=False):
     :type: str
     :param model_version: pedsnet model version
     :type: str
-    :param vocabulary: whether to make statements for vocabulary tables or
-    non-vocabulary tables
-    :type: bool
     :param force: ignore benign errors if true; see
     https://github.com/PEDSnet/pedsnetdcc/issues/10
+    :type: bool
+    :param vocabulary: whether to make statements for vocabulary tables or
+    non-vocabulary tables
     :type: bool
     :return: True
     :type: bool
@@ -215,7 +219,7 @@ def add_indexes(conn_str, model_version, force=False, vocabulary=False):
                             drop=False)
 
 
-def drop_indexes(conn_str, model_version, vocabulary=False, force=False):
+def drop_indexes(conn_str, model_version, force=False, vocabulary=False):
     """Execute ADD or DROP INDEX statements for a transformed PEDSnet schema.
 
     Depending on the value of the `vocabulary` parameter, statements are
@@ -227,11 +231,11 @@ def drop_indexes(conn_str, model_version, vocabulary=False, force=False):
     :type: str
     :param model_version: pedsnet model version
     :type: str
-    :param vocabulary: whether to make statements for vocabulary tables or
-    non-vocabulary tables
-    :type: bool
     :param force: ignore benign errors if true; see
     https://github.com/PEDSnet/pedsnetdcc/issues/10
+    :type: bool
+    :param vocabulary: whether to make statements for vocabulary tables or
+    non-vocabulary tables
     :type: bool
     :return: True
     :type: bool

--- a/pedsnetdcc/indexes.py
+++ b/pedsnetdcc/indexes.py
@@ -155,14 +155,9 @@ def _process_indexes(conn_str, model_version, error_mode, vocabulary=False,
                  'model_version': model_version, 'vocabulary': vocabulary})
     start_time = time.time()
 
-    indexes = _indexes_from_metadata(stock_metadata(model_version), TRANSFORMS,
-                                     vocabulary=vocabulary)
-
     stmts = StatementSet()
 
-    for stmt in [str(func(x).compile(
-            dialect=sqlalchemy.dialects.postgresql.dialect())).lstrip()
-            for x in indexes]:
+    for stmt in _indexes_sql(model_version, vocabulary, drop):
         stmts.add(Statement(stmt))
 
     # Execute the statements in parallel.

--- a/pedsnetdcc/indexes.py
+++ b/pedsnetdcc/indexes.py
@@ -39,27 +39,6 @@ def _indexes_from_metadata(metadata, transforms, vocabulary=False):
     return indexes
 
 
-def _indexes_from_model_version(model_version, vocabulary=False):
-    """Return list of SQLAlchemy index objects for the transformed metadata.
-
-    Given the stock metadata, for each transform `T` we invoke:
-
-        new_metadata = T.modify_metadata(metadata)
-
-    and at the end, we extract the indexes.
-
-    :param model_version: pedsnet model version
-    :type: str
-    :param vocabulary: whether to return indexes for vocabulary tables or
-    non-vocabulary tables
-    :type: bool
-    :return: list of index objects
-    :rtype: list(sqlalchemy.Index)
-    """
-    return _indexes_from_metadata(stock_metadata(model_version), TRANSFORMS,
-                                  vocabulary=vocabulary)
-
-
 def indexes_sql(model_version, drop=False, vocabulary=False):
     """Create ADD or DROP INDEX statements for a transformed PEDSnet schema.
 
@@ -81,7 +60,8 @@ def indexes_sql(model_version, drop=False, vocabulary=False):
     :return: list of SQL ADD or DROP INDEX statements
     :type: list(str)
     """
-    indexes = _indexes_from_model_version(model_version, vocabulary=vocabulary)
+    indexes = _indexes_from_metadata(stock_metadata(model_version), TRANSFORMS,
+                                     vocabulary=vocabulary)
     if not drop:
         func = CreateIndex
     else:

--- a/pedsnetdcc/indexes.py
+++ b/pedsnetdcc/indexes.py
@@ -1,8 +1,15 @@
+import logging
+import time
+
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.schema import CreateIndex, DropIndex
 
 from pedsnetdcc import VOCAB_TABLES, TRANSFORMS
-from pedsnetdcc.utils import stock_metadata
+from pedsnetdcc.utils import stock_metadata, check_stmt_err
+from pedsnetdcc.dict_logging import secs_since
+from pedsnetdcc.db import Statement, StatementSet
+
+logger = logging.getLogger(__name__)
 
 
 def _indexes_from_metadata(metadata, transforms, vocabulary=False):
@@ -39,32 +46,138 @@ def _indexes_from_metadata(metadata, transforms, vocabulary=False):
     return indexes
 
 
-def indexes_sql(model_version, drop=False, vocabulary=False):
-    """Create ADD or DROP INDEX statements for a transformed PEDSnet schema.
+def _indexes_sql(conn_str, model_version, vocabulary=False, drop=False):
+    """Return ADD or DROP INDEX statements for a transformed PEDSnet schema.
 
     Depending on the value of the `drop` parameter, either ADD or DROP
     statements are produced.
 
     Depending on the value of the `vocabulary` parameter, statements are
-    provided for either for a site schema (i.e. non-vocabulary tables in the
+    produced either for a site schema (i.e. non-vocabulary tables in the
     `pedsnet` data model) or for the vocabulary schema (vocabulary tables in
     the `pedsnet` data model).
 
     :param model_version: pedsnet model version
     :type: str
-    :param drop: whether to generate ADD or DROP statements
-    :type: bool
     :param vocabulary: whether to make statements for vocabulary tables or
     non-vocabulary tables
     :type: bool
-    :return: list of SQL ADD or DROP INDEX statements
+    :param drop: whether to generate ADD or DROP statements
+    :type: bool
+    :return: list of SQL statements
     :type: list(str)
     """
+
+    func = DropIndex if drop else CreateIndex
+
     indexes = _indexes_from_metadata(stock_metadata(model_version), TRANSFORMS,
                                      vocabulary=vocabulary)
+    return [str(func(x).compile(
+            dialect=postgresql.dialect())).lstrip() for x in indexes]
+
+
+def _process_indexes(conn_str, model_version, vocabulary=False, drop=False):
+    """Execute ADD or DROP INDEX statements for a transformed PEDSnet schema.
+
+    Depending on the value of the `drop` parameter, either ADD or DROP
+    statements are executed.
+
+    Depending on the value of the `vocabulary` parameter, statements are
+    executed either for a site schema (i.e. non-vocabulary tables in the
+    `pedsnet` data model) or for the vocabulary schema (vocabulary tables in
+    the `pedsnet` data model).
+
+    :param conn_str: database connection string
+    :type: str
+    :param model_version: pedsnet model version
+    :type: str
+    :param vocabulary: whether to make statements for vocabulary tables or
+    non-vocabulary tables
+    :type: bool
+    :param drop: whether to generate ADD or DROP statements
+    :type: bool
+    :return: True (returns only if statements succeed)
+    :type: bool
+    :raises DatabaseError: if any of the statement executions cause errors
+    """
+
     if not drop:
         func = CreateIndex
+        operation = 'creation'
     else:
         func = DropIndex
-    return [str(func(x).compile(
-                dialect=postgresql.dialect())).lstrip() for x in indexes]
+        operation = 'removal'
+
+    # Log start of the function and set the starting time.
+    logger.info({'msg': 'starting index {op}'.format(op=operation),
+                 'model_version': model_version, 'vocabulary': vocabulary})
+    start_time = time.time()
+
+    indexes = _indexes_from_metadata(stock_metadata(model_version), TRANSFORMS,
+                                     vocabulary=vocabulary)
+
+    stmts = StatementSet()
+
+    for stmt in [str(func(x).compile(
+            dialect=postgresql.dialect())).lstrip() for x in indexes]:
+        stmts.add(Statement(stmt))
+
+    # Execute the statements in parallel.
+    stmts.parallel_execute(conn_str)
+
+    # Check statements for any errors and raise exception if they are found.
+    for stmt in stmts:
+        check_stmt_err(stmt, 'foreign key creation')
+
+    # Log end of function.
+    logger.info({'msg': 'finished foreign key {op}'.format(op=operation),
+                 'elapsed': secs_since(start_time)})
+
+    # If reached without error, then success!
+    return True
+
+
+def add_indexes(conn_str, model_version, vocabulary=False):
+    """Execute ADD INDEX statements for a transformed PEDSnet schema.
+
+    Depending on the value of the `vocabulary` parameter, statements are
+    executed either for a site schema (i.e. non-vocabulary tables in the
+    `pedsnet` data model) or for the vocabulary schema (vocabulary tables in
+    the `pedsnet` data model).
+
+    :param conn_str: database connection string
+    :type: str
+    :param model_version: pedsnet model version
+    :type: str
+    :param vocabulary: whether to make statements for vocabulary tables or
+    non-vocabulary tables
+    :type: bool
+    :return: True
+    :type: bool
+    :raises DatabaseError: if any of the statement executions cause errors
+    """
+
+    return _process_indexes(conn_str, model_version, vocabulary, drop=False)
+
+
+def drop_indexes(conn_str, model_version, vocabulary=False):
+    """Execute ADD or DROP INDEX statements for a transformed PEDSnet schema.
+
+    Depending on the value of the `vocabulary` parameter, statements are
+    executed either for a site schema (i.e. non-vocabulary tables in the
+    `pedsnet` data model) or for the vocabulary schema (vocabulary tables in
+    the `pedsnet` data model).
+
+    :param conn_str: database connection string
+    :type: str
+    :param model_version: pedsnet model version
+    :type: str
+    :param vocabulary: whether to make statements for vocabulary tables or
+    non-vocabulary tables
+    :type: bool
+    :return: True
+    :type: bool
+    :raises DatabaseError: if any of the statement executions cause errors
+    """
+
+    return _process_indexes(conn_str, model_version, vocabulary, drop=True)

--- a/pedsnetdcc/tests/indexes_test.py
+++ b/pedsnetdcc/tests/indexes_test.py
@@ -1,9 +1,6 @@
-import os
 import unittest
 
-from pedsnetdcc.indexes import indexes_sql
-
-import pedsnetdcc
+from pedsnetdcc.indexes import _indexes_sql, add_indexes, drop_indexes
 
 class IndexesTest(unittest.TestCase):
 
@@ -11,7 +8,7 @@ class IndexesTest(unittest.TestCase):
         self.model_version = '2.2.0'
 
     def test_add_indexes(self):
-        sql = indexes_sql(self.model_version)
+        sql = _indexes_sql(self.model_version)
 
         sample_expected = (
             'CREATE INDEX obs_otcn_89a4742c38ecb8ba35_ix ON observation (observation_type_concept_name)',
@@ -28,7 +25,7 @@ class IndexesTest(unittest.TestCase):
             self.assertNotIn(sample, sql)
 
     def test_drop_indexes(self):
-        sql = indexes_sql(self.model_version, drop=True)
+        sql = _indexes_sql(self.model_version, drop=True)
 
         sample_expected = (
             'DROP INDEX obs_otcn_89a4742c38ecb8ba35_ix',
@@ -45,7 +42,7 @@ class IndexesTest(unittest.TestCase):
             self.assertNotIn(sample, sql)
 
     def test_add_indexes_for_vocabulary(self):
-        sql = indexes_sql(self.model_version, vocabulary=True)
+        sql = _indexes_sql(self.model_version, vocabulary=True)
 
         sample_expected = (
             'CREATE INDEX idx_concept_class_id ON concept (concept_class_id)',

--- a/pedsnetdcc/tests/indexes_test.py
+++ b/pedsnetdcc/tests/indexes_test.py
@@ -1,80 +1,62 @@
+import os
 import unittest
 
-from sqlalchemy import MetaData, Table, Column, DateTime, Integer, String
+from pedsnetdcc.indexes import indexes_sql
 
-from pedsnetdcc.age_transform import AgeTransform
-from pedsnetdcc.concept_name_transform import ConceptNameTransform
-from pedsnetdcc.site_name_transform import SiteNameTransform
-
-from pedsnetdcc.indexes import add_indexes_sql, drop_indexes_sql, indexes
+import pedsnetdcc
 
 class IndexesTest(unittest.TestCase):
 
     def setUp(self):
-        self.metadata = MetaData()
-
-        # Add first of two test tables to empty metadata
-        self.table1 = Table('table1', self.metadata,
-                            Column('start_time', DateTime),
-                            Column('table1_concept_id', Integer),
-                            Column('person_id', Integer, index=True))
-
-        # Add second of two test tables to metadata
-        self.table2 = Table('table2', self.metadata,
-                            Column('start_time', DateTime),
-                            Column('person_id', Integer))
-
-        # Add a `person` table to metadata
-        self.person = Table('person', self.metadata,
-                            Column('person_id', Integer),
-                            Column('time_of_birth', DateTime))
-
-        # Add a test vocab table, 'concept' to metadata
-        self.table1 = Table('concept', self.metadata,
-                            Column('concept_id', Integer, index=True),
-                            Column('concept_name', String, index=True))
-
-        AgeTransform.columns = (
-            ('table1', 'start_time'),
-        )
-
-        self.transforms = (
-        AgeTransform, ConceptNameTransform, SiteNameTransform)
+        self.model_version = '2.2.0'
 
     def test_add_indexes(self):
-        idx_list = indexes(self.metadata, self.transforms)
-        sql = add_indexes_sql(idx_list)
+        sql = indexes_sql(self.model_version)
 
-        expected = set([
-            'CREATE INDEX per_s_1a2331c4688eab6532680_ix ON person (site)',
-            'CREATE INDEX tab_s_50b3103c7ae81ac72b766_ix ON table2 (site)',
-            'CREATE INDEX tab_s_e8e4cc181f175c06e6d80_ix ON table1 (site)',
-            'CREATE INDEX tab_tcn_8b2e3c0037a3e649c77_ix ON table1 (table1_concept_name)',
-            'CREATE INDEX tab_saim_5c10efef3b7b0f2c42_ix ON table1 (start_age_in_months)',
-            'CREATE INDEX ix_table1_person_id ON table1 (person_id)'
-        ])
-        self.assertEquals(set(sql), expected)
+        sample_expected = (
+            'CREATE INDEX obs_otcn_89a4742c38ecb8ba35_ix ON observation (observation_type_concept_name)',
+            'CREATE INDEX dea_s_4906dc6995505fc71431f_ix ON death (site)',
+            'CREATE INDEX vis_vsaim_f1537dca8da9ab914_ix ON visit_occurrence (visit_start_age_in_months)',
+        )
+        for sample in sample_expected:
+            self.assertIn(sample, sql)
+
+        sample_not_expected = (
+            'CREATE INDEX idx_concept_vocabluary_id ON concept (vocabulary_id)',
+        )
+        for sample in sample_not_expected:
+            self.assertNotIn(sample, sql)
 
     def test_drop_indexes(self):
-        idx_list = indexes(self.metadata, self.transforms)
-        sql = drop_indexes_sql(idx_list)
+        sql = indexes_sql(self.model_version, drop=True)
 
-        expected = set([
-            'DROP INDEX per_s_1a2331c4688eab6532680_ix',
-            'DROP INDEX tab_s_50b3103c7ae81ac72b766_ix',
-            'DROP INDEX tab_s_e8e4cc181f175c06e6d80_ix',
-            'DROP INDEX tab_tcn_8b2e3c0037a3e649c77_ix',
-            'DROP INDEX tab_saim_5c10efef3b7b0f2c42_ix',
-            'DROP INDEX ix_table1_person_id'
-        ])
-        self.assertEquals(set(sql), expected)
+        sample_expected = (
+            'DROP INDEX obs_otcn_89a4742c38ecb8ba35_ix',
+            'DROP INDEX dea_s_4906dc6995505fc71431f_ix',
+            'DROP INDEX vis_vsaim_f1537dca8da9ab914_ix'
+        )
+        for sample in sample_expected:
+            self.assertIn(sample, sql)
+
+        sample_not_expected = (
+            'CREATE INDEX idx_concept_vocabluary_id ON concept (vocabulary_id)',
+        )
+        for sample in sample_not_expected:
+            self.assertNotIn(sample, sql)
 
     def test_add_indexes_for_vocabulary(self):
-        idx_list = indexes(self.metadata, self.transforms, vocabulary=True)
-        sql = add_indexes_sql(idx_list)
+        sql = indexes_sql(self.model_version, vocabulary=True)
 
-        expected = set([
-            'CREATE INDEX ix_concept_concept_name ON concept (concept_name)',
-            'CREATE INDEX ix_concept_concept_id ON concept (concept_id)'
-        ])
-        self.assertEqual(set(sql), expected)
+        sample_expected = (
+            'CREATE INDEX idx_concept_class_id ON concept (concept_class_id)',
+            'CREATE INDEX idx_concept_synonym_id ON concept_synonym (concept_id)'
+        )
+        for sample in sample_expected:
+            self.assertIn(sample, sql)
+
+        sample_not_expected = (
+            'CREATE INDEX con_lcn_f7a508db6a172c78291_ix ON concept_synonym (language_concept_name)',
+            'CREATE INDEX con_s_d9ad76e415cb919c49e49_ix ON concept_class (site)'
+        )
+        for sample in sample_not_expected:
+            self.assertNotIn(sample, sql)

--- a/pedsnetdcc/tests/indexes_test.py
+++ b/pedsnetdcc/tests/indexes_test.py
@@ -1,0 +1,80 @@
+import unittest
+
+from sqlalchemy import MetaData, Table, Column, DateTime, Integer, String
+
+from pedsnetdcc.age_transform import AgeTransform
+from pedsnetdcc.concept_name_transform import ConceptNameTransform
+from pedsnetdcc.site_name_transform import SiteNameTransform
+
+from pedsnetdcc.indexes import add_indexes_sql, drop_indexes_sql, indexes
+
+class IndexesTest(unittest.TestCase):
+
+    def setUp(self):
+        self.metadata = MetaData()
+
+        # Add first of two test tables to empty metadata
+        self.table1 = Table('table1', self.metadata,
+                            Column('start_time', DateTime),
+                            Column('table1_concept_id', Integer),
+                            Column('person_id', Integer, index=True))
+
+        # Add second of two test tables to metadata
+        self.table2 = Table('table2', self.metadata,
+                            Column('start_time', DateTime),
+                            Column('person_id', Integer))
+
+        # Add a `person` table to metadata
+        self.person = Table('person', self.metadata,
+                            Column('person_id', Integer),
+                            Column('time_of_birth', DateTime))
+
+        # Add a test vocab table, 'concept' to metadata
+        self.table1 = Table('concept', self.metadata,
+                            Column('concept_id', Integer, index=True),
+                            Column('concept_name', String, index=True))
+
+        AgeTransform.columns = (
+            ('table1', 'start_time'),
+        )
+
+        self.transforms = (
+        AgeTransform, ConceptNameTransform, SiteNameTransform)
+
+    def test_add_indexes(self):
+        idx_list = indexes(self.metadata, self.transforms)
+        sql = add_indexes_sql(idx_list)
+
+        expected = set([
+            'CREATE INDEX per_s_1a2331c4688eab6532680_ix ON person (site)',
+            'CREATE INDEX tab_s_50b3103c7ae81ac72b766_ix ON table2 (site)',
+            'CREATE INDEX tab_s_e8e4cc181f175c06e6d80_ix ON table1 (site)',
+            'CREATE INDEX tab_tcn_8b2e3c0037a3e649c77_ix ON table1 (table1_concept_name)',
+            'CREATE INDEX tab_saim_5c10efef3b7b0f2c42_ix ON table1 (start_age_in_months)',
+            'CREATE INDEX ix_table1_person_id ON table1 (person_id)'
+        ])
+        self.assertEquals(set(sql), expected)
+
+    def test_drop_indexes(self):
+        idx_list = indexes(self.metadata, self.transforms)
+        sql = drop_indexes_sql(idx_list)
+
+        expected = set([
+            'DROP INDEX per_s_1a2331c4688eab6532680_ix',
+            'DROP INDEX tab_s_50b3103c7ae81ac72b766_ix',
+            'DROP INDEX tab_s_e8e4cc181f175c06e6d80_ix',
+            'DROP INDEX tab_tcn_8b2e3c0037a3e649c77_ix',
+            'DROP INDEX tab_saim_5c10efef3b7b0f2c42_ix',
+            'DROP INDEX ix_table1_person_id'
+        ])
+        self.assertEquals(set(sql), expected)
+
+    def test_add_indexes_for_vocabulary(self):
+        idx_list = indexes(self.metadata, self.transforms, vocabulary=True)
+        sql = add_indexes_sql(idx_list)
+
+        expected = set([
+            'CREATE INDEX ix_concept_concept_name ON concept (concept_name)',
+            'CREATE INDEX ix_concept_concept_id ON concept (concept_id)'
+        ])
+        self.assertEqual(set(sql), expected)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ click
 logutils
 psycopg2
 sqlalchemy
+dmsa

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,5 @@
 click
-mock
+dmsa
 psycopg2
 sqlalchemy
 testing.postgresql

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,5 @@
 click
+mock
 psycopg2
 sqlalchemy
 testing.postgresql


### PR DESCRIPTION
This isn't ready for merging because it needs to be integrated with the new statement executor.  Currently there is a top-level function:

    indexes_sql(model_version, drop=False, vocabulary=False)

that can generate the index statements for the transformed data model. For now the transformations are defined in a list in pedsnetdcc/__init__.py.

