### PR TITLE
Add ID Mapping Transform and tests

### DIFF
--- a/pedsnetdcc/__init__.py
+++ b/pedsnetdcc/__init__.py
@@ -37,16 +37,25 @@ VOCAB_TABLES = (
     'source_to_concept_map'
 )
 
+# TODO: Generate this map dynamically at runtime from the distinct
+# fact_relationship.domain_concept_id_{1,2} values and the domain table.
+FACT_RELATIONSHIP_DOMAINS = {
+    'observation': 27,
+    'measurement': 21,
+    'visit_occurrence': 8
+}
+
 _dms_var = 'PEDSNETDCC_DMS_URL'
 if _dms_var in os.environ:
     DATA_MODELS_SERVICE = os.environ[_dms_var]
 else:
     DATA_MODELS_SERVICE = 'https://data-models-service.research.chop.edu/'
 
-from pedsnetdcc.age_transform import AgeTransform
-from pedsnetdcc.concept_name_transform import ConceptNameTransform
-from pedsnetdcc.site_name_transform import SiteNameTransform
+from pedsnetdcc.age_transform import AgeTransform                   # noqa
+from pedsnetdcc.concept_name_transform import ConceptNameTransform  # noqa
+from pedsnetdcc.site_name_transform import SiteNameTransform        # noqa
 
 TRANSFORMS = (AgeTransform, ConceptNameTransform, SiteNameTransform)
 
-__all__ = (__version__, VOCAB_TABLES, DATA_MODELS_SERVICE, TRANSFORMS)
+__all__ = (__version__, VOCAB_TABLES, DATA_MODELS_SERVICE, TRANSFORMS,
+           FACT_RELATIONSHIP_DOMAINS)

--- a/pedsnetdcc/abstract_transform.py
+++ b/pedsnetdcc/abstract_transform.py
@@ -28,13 +28,16 @@ class Transform(object):
     __metaclass__ = ABCMeta
 
     @classmethod
-    def pre_transform(cls, conn_str):
+    def pre_transform(cls, conn_str, metadata=None, table_name=None):
         """Execute statements required before a transform.
 
         A Transform can override this method to execute prerequisite
         statements for a transform, e.g. creating database functions, etc.
 
-        :param str conn_str: libpq connection string or URI
+        :param str conn_str:   libpq connection string or URI
+        :param sqlalchemy.schema.MetaData metadata: object describing tables
+        and columns, optional
+        :param str table_name: table to be transformed, optional
         :return: None
         """
         pass

--- a/pedsnetdcc/abstract_transform.py
+++ b/pedsnetdcc/abstract_transform.py
@@ -28,7 +28,7 @@ class Transform(object):
     __metaclass__ = ABCMeta
 
     @classmethod
-    def pre_transform(cls, conn_str, metadata=None, table_name=None):
+    def pre_transform(cls, conn_str, metadata):
         """Execute statements required before a transform.
 
         A Transform can override this method to execute prerequisite
@@ -36,8 +36,7 @@ class Transform(object):
 
         :param str conn_str:   libpq connection string or URI
         :param sqlalchemy.schema.MetaData metadata: object describing tables
-        and columns, optional
-        :param str table_name: table to be transformed, optional
+        and columns
         :return: None
         """
         pass

--- a/pedsnetdcc/age_transform.py
+++ b/pedsnetdcc/age_transform.py
@@ -67,7 +67,7 @@ class AgeTransform(Transform):
         return False
 
     @classmethod
-    def pre_transform(cls, conn_str):
+    def pre_transform(cls, conn_str, table_name=None):
         """Define PL/SQL functions needed for the age transform
         See also Transform.pre_transform.
         """

--- a/pedsnetdcc/age_transform.py
+++ b/pedsnetdcc/age_transform.py
@@ -67,8 +67,10 @@ class AgeTransform(Transform):
         return False
 
     @classmethod
-    def pre_transform(cls, conn_str, table_name=None):
-        """Define PL/SQL functions needed for the age transform
+    def pre_transform(cls, conn_str, metadata):
+        """Define PL/SQL functions needed for the age transform. The metadata
+        argument is accepted to conform to the abstract transformation class
+        definition but not needed or used for this transformation.
         See also Transform.pre_transform.
         """
         with psycopg2.connect(conn_str) as conn:

--- a/pedsnetdcc/check_fact_relationship.py
+++ b/pedsnetdcc/check_fact_relationship.py
@@ -6,6 +6,9 @@ from pedsnetdcc.db import Statement, StatementSet
 from pedsnetdcc.dict_logging import secs_since
 from pedsnetdcc.utils import check_stmt_data, check_stmt_err, combine_dicts
 
+# TODO: Make below code dependent on the pedsnetdcc.FACT_RELATIONSHIP_DOMAINS
+# dictionary, allowing for easy addition of new domains to the table.
+
 # The below total fact_relationship record count statements assume that
 # domain_concept_id_1 defines a record as being in a domain.
 

--- a/pedsnetdcc/id_mapping_transform.py
+++ b/pedsnetdcc/id_mapping_transform.py
@@ -2,7 +2,7 @@ import logging
 import sqlalchemy
 import time
 
-from pedsnetdcc import VOCAB_TABLES
+from pedsnetdcc import VOCAB_TABLES, FACT_RELATIONSHIP_DOMAINS
 from pedsnetdcc.abstract_transform import Transform
 from pedsnetdcc.db import Statement, StatementList
 from pedsnetdcc.dict_logging import secs_since
@@ -37,109 +37,124 @@ last_id_table_name_tmpl = "dcc_{table_name}_id"
 logger = logging.getLogger(__name__)
 
 
+class IDMappingPreTransformStatementList(StatementList):
+    pass
+
+
 class IDMappingTransform(Transform):
 
     @classmethod
-    def pre_transform(cls, conn_str, metadata=None, table_name=None):
-        """Generate DCC IDs for the table.
-
-        This needs to be run for every table before any tables are actually
-        transformed since they need each others new IDs to place in foreign
-        key fields.
+    def pre_transform(cls, conn_str, metadata):
+        """Generate DCC IDs in the database.
 
         See also Transform.pre_transform.
+
+        :raises ValueError: if any of the non-vocabulary tables in metadata
+                            have composite primary keys
         """
 
         logger.info({'msg': 'starting ID mapping pre-transform'})
         starttime = time.time()
 
-        # Get table object and start to build results map, which will be used
-        # throughout for formatting SQL statements.
-        table = metadata.tables[table_name]
-        results = {'table_name': table_name}
+        for table_name in set(metadata.tables.keys()) - set(VOCAB_TABLES):
 
-        # Error if the table has more than one primary key column.
-        if len(list(table.primary_key.columns.keys())) > 1:
-            err = ValueError('cannot generate IDs for multi-column primary key'
-                             ' on table {0}'.format(table_name))
-            logger.critical({'msg': 'exiting ID mapping pre-transform',
-                             'table': table_name, 'err': err})
-            raise err
+            if table_name == 'fact_relationship':
+                continue
 
-        # Get primary key, mapping tabl, and last id tracking table names.
-        # The mapping table and last id tracking table names are defined
-        # by convention.
-        results['pkey_name'] = list(table.primary_key.columns.keys())[0]
-        results['map_table_name'] = map_table_name_tmpl.format(**results)
-        results['last_id_table_name'] = last_id_table_name_tmpl.\
-            format(**results)
+            # Get table object and start to build tpl_vars map, which will be
+            # used throughout for formatting SQL statements.
+            table = metadata.tables[table_name]
+            tpl_vars = {'table_name': table_name}
 
-        # Build the statement to count how many new ID mappings are needed.
-        new_id_count_stmt = Statement(new_id_count_sql.format(**results),
-                                      new_id_count_msg.format(**results))
+            # Error if the table has more than one primary key column.
+            if len(list(table.primary_key.columns.keys())) > 1:
+                err = ValueError('cannot generate IDs for multi-column primary'
+                                 ' key on table {0}'.format(table_name))
+                logger.error({'msg': 'exiting ID mapping pre-transform',
+                              'table': table_name, 'err': err})
+                raise err
 
-        # Execute the new ID mapping count statement and ensure it didn't
-        # error and did return a result.
-        new_id_count_stmt.execute(conn_str)
-        check_stmt_err(new_id_count_stmt, 'ID mapping pre-transform')
-        check_stmt_data(new_id_count_stmt, 'ID mapping pre-transform')
+            # Error if the table has no primary key column (except death).
+            if len(list(table.primary_key.columns.keys())) == 0:
+                if table_name == 'death':
+                    continue
+                err = ValueError('cannot generate IDs for table {0} with no'
+                                 ' primary key'.format(table_name))
+                logger.error({'msg': 'exiting ID mapping pre-transform',
+                              'table': table_name, 'err': err})
+                raise err
 
-        # Get the actual count of new ID maps needed and log it.
-        results['new_id_count'] = new_id_count_stmt.data[0][0]
-        logger.info({'msg': 'counted new IDs needed', 'table': table_name,
-                     'count': results['new_id_count']})
+            # Get primary key, mapping table, and last id tracking table names.
+            # The mapping table and last id tracking table names are defined
+            # by convention.
+            tpl_vars['pkey_name'] = list(table.primary_key.columns.keys())[0]
+            tpl_vars['map_table_name'] = map_table_name_tmpl.format(**tpl_vars)
+            tpl_vars['last_id_table_name'] = last_id_table_name_tmpl.\
+                format(**tpl_vars)
 
-        # Build list of two last id table update statements that need to occur
-        # in a single transaction to prevent race conditions.
-        update_last_id_stmts = StatementList()
-        update_last_id_stmts.append(Statement(
-            lock_last_id_sql.format(**results),
-            lock_last_id_msg.format(**results)))
-        update_last_id_stmts.append(Statement(
-            update_last_id_sql.format(**results),
-            update_last_id_msg.format(**results)))
+            # Build the statement to count how many new ID mappings are needed.
+            new_id_count_stmt = Statement(new_id_count_sql.format(**tpl_vars),
+                                          new_id_count_msg.format(**tpl_vars))
 
-        # Execute last id table update statements and ensure they didn't error
-        # and the second one returned results.
-        update_last_id_stmts.serial_execute(conn_str, transaction=True)
+            # Execute the new ID mapping count statement and ensure it didn't
+            # error and did return a result.
+            new_id_count_stmt.execute(conn_str)
+            check_stmt_err(new_id_count_stmt, 'ID mapping pre-transform')
+            check_stmt_data(new_id_count_stmt, 'ID mapping pre-transform')
 
-        for stmt in update_last_id_stmts:
-            check_stmt_err(stmt, 'ID mapping pre-transform')
-        check_stmt_data(update_last_id_stmts[1], 'ID mapping pre-transform')
+            # Get the actual count of new ID maps needed and log it.
+            tpl_vars['new_id_count'] = new_id_count_stmt.data[0][0]
+            logger.info({'msg': 'counted new IDs needed', 'table': table_name,
+                         'count': tpl_vars['new_id_count']})
 
-        # Get the old and new last IDs from the second update statement.
-        results['old_last_id'] = update_last_id_stmts[1].data[0][0]
-        results['new_last_id'] = update_last_id_stmts[1].data[0][1]
-        logger.info({'msg': 'last ID tracking table updated',
-                     'table': table_name,
-                     'old_last})d': results['old_last_id'],
-                     'new_last_id': results['new_last_id']})
+            # Build list of two last id table update statements that need to
+            # occur in a single transaction to prevent race conditions.
+            update_last_id_stmts = StatementList()
+            update_last_id_stmts.append(Statement(
+                lock_last_id_sql.format(**tpl_vars),
+                lock_last_id_msg.format(**tpl_vars)))
+            update_last_id_stmts.append(Statement(
+                update_last_id_sql.format(**tpl_vars),
+                update_last_id_msg.format(**tpl_vars)))
 
-        # Build statement to generate new ID maps.
-        insert_new_maps_stmt = Statement(
-            insert_new_maps_sql.format(**results),
-            insert_new_maps_msg.format(**results))
+            # Execute last id table update statements and ensure they didn't
+            # error and the second one returned results.
+            update_last_id_stmts.serial_execute(conn_str, transaction=True)
 
-        # Execute new map generation statement and ensure it didn't error.
-        insert_new_maps_stmt.execute(conn_str)
-        check_stmt_err(insert_new_maps_stmt, 'id mapping pre-transform')
-        logging.info({'msg': 'generated new ID mappings', 'table': table_name,
-                      'count': insert_new_maps_stmt.rowcount,
-                      'elapsed': secs_since(starttime)})
+            for stmt in update_last_id_stmts:
+                check_stmt_err(stmt, 'ID mapping pre-transform')
+            check_stmt_data(update_last_id_stmts[1],
+                            'ID mapping pre-transform')
+
+            # Get the old and new last IDs from the second update statement.
+            tpl_vars['old_last_id'] = update_last_id_stmts[1].data[0][0]
+            tpl_vars['new_last_id'] = update_last_id_stmts[1].data[0][1]
+            logger.info({'msg': 'last ID tracking table updated',
+                         'table': table_name,
+                         'old_last_id': tpl_vars['old_last_id'],
+                         'new_last_id': tpl_vars['new_last_id']})
+
+            # Build statement to generate new ID maps.
+            insert_new_maps_stmt = Statement(
+                insert_new_maps_sql.format(**tpl_vars),
+                insert_new_maps_msg.format(**tpl_vars))
+
+            # Execute new map generation statement and ensure it didn't error.
+            insert_new_maps_stmt.execute(conn_str)
+            check_stmt_err(insert_new_maps_stmt, 'id mapping pre-transform')
+            logging.info({'msg': 'generated new ID mappings',
+                          'table': table_name,
+                          'count': insert_new_maps_stmt.rowcount,
+                          'elapsed': secs_since(starttime)})
 
     @classmethod
-    def modify_select(cls, metadata, table_name, select=None, join=None):
+    def modify_select(cls, metadata, table_name, select, join):
         """Alter foreign key columns to get mapped DCC IDs.
 
         The primary key and each foreign key which points at a data table
         (i.e., not a vocabulary table) is altered to instead get the dcc_id's
         from the mapping table, which requires a join to be added.
         """
-
-        # Raise error if attempted on a vocabulary table.
-        if table_name in VOCAB_TABLES:
-            raise ValueError('ID mapping should not be performed on vocabulary'
-                             ' tables like {0}'.format(table_name))
 
         # Get table object.
         table = metadata.tables[table_name]
@@ -149,41 +164,43 @@ class IDMappingTransform(Transform):
             raise ValueError('cannot map IDs for multi-column primary key'
                              ' on table {0}'.format(table_name))
 
-        # Get primary key name and mapping table name, defined by convention.
-        pkey_name = list(table.primary_key.columns.keys())[0]
-        map_table_name = map_table_name_tmpl.format(table_name=table_name)
+        # Skip primary key mapping if there is none (fact_relationship and pre
+        # 2.3 death tables).
+        if not len(list(table.primary_key.columns.keys())) == 0:
 
-        # Construct table object for mapping table.
-        map_table = sqlalchemy.Table(
-            map_table_name, metadata,
-            sqlalchemy.Column('dcc_id', sqlalchemy.Integer),
-            sqlalchemy.Column('site_id', sqlalchemy.Integer))
+            # Get primary key name and mapping table name, defined by
+            # convention.
+            pkey_name = list(table.primary_key.columns.keys())[0]
+            map_table_name = map_table_name_tmpl.format(table_name=table_name)
 
-        # Add a join to the mapping table.
-        if join:
+            # Construct table object for mapping table.
+            map_table = sqlalchemy.Table(
+                map_table_name, metadata,
+                sqlalchemy.Column('dcc_id', sqlalchemy.Integer),
+                sqlalchemy.Column('site_id', sqlalchemy.Integer))
+
             join = join.join(map_table, table.c[pkey_name] ==
                              map_table.c['site_id'])
-        else:
-            join = join or sqlalchemy.join(table, map_table,
-                                           table.c[pkey_name] ==
-                                           map_table.c['site_id'])
 
-        # Create a new select object, because we need to get rid of the
-        # primary key column.
-        select = select or sqlalchemy.select([table])
-        new_select = sqlalchemy.select()
+            # Create a new select object, because we need to replace the
+            # primary key column with the joined mapping table dcc_id column.
+            new_select = sqlalchemy.select()
 
-        # Get rid of the primary key column.
-        for c in select.inner_columns:
-            if c.name != pkey_name:
-                new_select.append_column(c)
+            # Get rid of the primary key column.
+            for c in select.inner_columns:
+                if c.name != pkey_name:
+                    new_select.append_column(c)
 
-        # Add the mapping table dcc_id column as the primary key column.
-        new_select.append_column(map_table.c['dcc_id'].label(pkey_name))
+            # Add the mapping table dcc_id column as the primary key column.
+            new_select.append_column(map_table.c['dcc_id'].label(pkey_name))
 
-        # Put the new select object back in the original var for further use.
-        select = new_select
+            # Add the original site primary key as the site_id column.
+            new_select.append_column(table.c[pkey_name].label('site_id'))
 
+            # Put the new select object in the original var for further use.
+            select = new_select
+
+        # Add a mapping join and column substitution for each foreign key.
         for fkey in table.foreign_key_constraints:
 
             ref_table_name = fkey.referred_table.name
@@ -192,7 +209,7 @@ class IDMappingTransform(Transform):
             if ref_table_name in VOCAB_TABLES:
                 continue
 
-            # Get primary key name and mapping table name, defined by
+            # Get foreign key name and mapping table name, defined by
             # convention.
             fkey_name = fkey.column_keys[0]
             map_table_name = map_table_name_tmpl.\
@@ -209,23 +226,89 @@ class IDMappingTransform(Transform):
             # the final product.
             isouter = table.c[fkey_name].nullable
 
-            # Add a join to the mapping table.
+            # Add a join to the mapping table.)
             join = join.join(map_table, table.c[fkey_name] ==
                              map_table.c['site_id'], isouter=isouter)
 
-            # Create a new select object, because we need to get rid of the
-            # primary key column.
+            # Create a new select object, because we need to replace the
+            # foreign key column with the joined mapping table dcc_id column.
             new_select = sqlalchemy.select()
 
-            # Get rid of the primary key column.
+            # Get rid of the foreign key column.
             for c in select.inner_columns:
                 if c.name != fkey_name:
                     new_select.append_column(c)
 
-            # Add the mapping table dcc_id column as the primary key column.
+            # Add the mapping table dcc_id column as the foreign key column.
             new_select.append_column(map_table.c['dcc_id'].label(fkey_name))
 
             # Put the new select object back in the original var for next use.
+            select = new_select
+
+        # Special handling for fact_relationship.
+        if table_name == 'fact_relationship':
+
+            case_1 = {}
+            case_2 = {}
+
+            for ref_table_name, domain_concept_id in \
+                    FACT_RELATIONSHIP_DOMAINS.items():
+
+                # Get mapping table name, by convention.
+                map_table_name = map_table_name_tmpl.\
+                    format(table_name=ref_table_name)
+
+                # Construct table object for mapping table.
+                map_table = sqlalchemy.Table(
+                    map_table_name, metadata,
+                    sqlalchemy.Column('dcc_id', sqlalchemy.Integer),
+                    sqlalchemy.Column('site_id', sqlalchemy.Integer))
+
+                # Make two aliases of the mapping table for joining to each of
+                # the fact_id columns.
+                map_table_1 = map_table.alias()
+                map_table_2 = map_table.alias()
+
+                # Add two joins to the mapping table
+                join = join.join(map_table_1, sqlalchemy.and_(
+                                     table.c['fact_id_1'] ==
+                                     map_table_1.c['site_id'],
+                                     table.c['domain_concept_id_1'] ==
+                                     domain_concept_id),
+                                 isouter=True)
+                join = join.join(map_table_2, sqlalchemy.and_(
+                                     table.c['fact_id_2'] ==
+                                     map_table_2.c['site_id'],
+                                     table.c['domain_concept_id_2'] ==
+                                     domain_concept_id),
+                                 isouter=True)
+
+                # Add conditions to the case dictionary constructs.
+                case_1[domain_concept_id] = map_table_1.c['dcc_id']
+                case_2[domain_concept_id] = map_table_2.c['dcc_id']
+
+            # Create a new select object, because we need to replace the
+            # fact_id columns with the case constructs.
+            new_select = sqlalchemy.select()
+
+            # Get rid of the fact_id columns.
+            for c in select.inner_columns:
+                if c.name not in ['fact_id_1', 'fact_id_2']:
+                    new_select.append_column(c)
+
+            # Add the case constructs as the new fact_id columns.
+            new_select.append_column(sqlalchemy.case(
+                case_1, value=table.c['domain_concept_id_1']).
+                label('fact_id_1'))
+            new_select.append_column(sqlalchemy.case(
+                case_2, value=table.c['domain_concept_id_2']).
+                label('fact_id_2'))
+
+            # Add the original fact_id columns as the site_id columns.
+            new_select.append_column(table.c['fact_id_1'].label('site_id_1'))
+            new_select.append_column(table.c['fact_id_2'].label('site_id_2'))
+
+            # Put the new select object in the original var for further use.
             select = new_select
 
         return select, join
@@ -235,5 +318,13 @@ class IDMappingTransform(Transform):
         """Helper function to apply the transformation to a table in place.
         See Transform.modify_table for signature.
         """
-        new_col = sqlalchemy.Column('site_id', sqlalchemy.String(32))
-        table.append_column(new_col)
+
+        if len(list(table.primary_key.columns.keys())) == 1:
+            new_col = sqlalchemy.Column('site_id', sqlalchemy.String(32))
+            table.append_column(new_col)
+
+        if table.name == 'fact_relationship':
+            new_col_1 = sqlalchemy.Column('site_id_1', sqlalchemy.String(32))
+            new_col_2 = sqlalchemy.Column('site_id_2', sqlalchemy.String(32))
+            table.append_column(new_col_1)
+            table.append_column(new_col_2)

--- a/pedsnetdcc/id_mapping_transform.py
+++ b/pedsnetdcc/id_mapping_transform.py
@@ -37,10 +37,6 @@ last_id_table_name_tmpl = "dcc_{table_name}_id"
 logger = logging.getLogger(__name__)
 
 
-class IDMappingPreTransformStatementList(StatementList):
-    pass
-
-
 class IDMappingTransform(Transform):
 
     @classmethod

--- a/pedsnetdcc/id_mapping_transform.py
+++ b/pedsnetdcc/id_mapping_transform.py
@@ -1,0 +1,239 @@
+import logging
+import sqlalchemy
+import time
+
+from pedsnetdcc import VOCAB_TABLES
+from pedsnetdcc.abstract_transform import Transform
+from pedsnetdcc.db import Statement, StatementList
+from pedsnetdcc.dict_logging import secs_since
+from pedsnetdcc.utils import check_stmt_err, check_stmt_data
+
+# Pre-transform ID map creation statements.
+
+new_id_count_sql = """SELECT COUNT(*)
+FROM {table_name} LEFT JOIN {map_table_name} ON {pkey_name} = site_id
+WHERE site_id IS NULL"""
+new_id_count_msg = "counting new IDs needed for {table_name}"
+
+lock_last_id_sql = """LOCK {last_id_table_name}"""
+lock_last_id_msg = "locking {table_name} last ID tracking table for update"
+
+update_last_id_sql = """UPDATE {last_id_table_name} AS new
+SET last_id = new.last_id + '{new_id_count}'::integer
+FROM {last_id_table_name} AS old RETURNING old.last_id, new.last_id"""
+update_last_id_msg = "updating {table_name} last ID tracking table to reserve new IDs"  # noqa
+
+insert_new_maps_sql = """INSERT INTO {map_table_name} (site_id, dcc_id)
+SELECT {pkey_name}, row_number() over (range unbounded preceding) + '{old_last_id}'::integer
+FROM {table_name} LEFT JOIN {map_table_name} on {pkey_name} = site_id
+WHERE site_id IS NULL"""  # noqa
+insert_new_maps_msg = "inserting new {table_name} ID mappings into map table"
+
+# Mapping and last ID table naming conventions.
+
+map_table_name_tmpl = "{table_name}_ids"
+last_id_table_name_tmpl = "dcc_{table_name}_id"
+
+logger = logging.getLogger(__name__)
+
+
+class IDMappingTransform(Transform):
+
+    @classmethod
+    def pre_transform(cls, conn_str, metadata=None, table_name=None):
+        """Generate DCC IDs for the table.
+
+        This needs to be run for every table before any tables are actually
+        transformed since they need each others new IDs to place in foreign
+        key fields.
+
+        See also Transform.pre_transform.
+        """
+
+        logger.info({'msg': 'starting ID mapping pre-transform'})
+        starttime = time.time()
+
+        # Get table object and start to build results map, which will be used
+        # throughout for formatting SQL statements.
+        table = metadata.tables[table_name]
+        results = {'table_name': table_name}
+
+        # Error if the table has more than one primary key column.
+        if len(list(table.primary_key.columns.keys())) > 1:
+            err = ValueError('cannot generate IDs for multi-column primary key'
+                             ' on table {0}'.format(table_name))
+            logger.critical({'msg': 'exiting ID mapping pre-transform',
+                             'table': table_name, 'err': err})
+            raise err
+
+        # Get primary key, mapping tabl, and last id tracking table names.
+        # The mapping table and last id tracking table names are defined
+        # by convention.
+        results['pkey_name'] = list(table.primary_key.columns.keys())[0]
+        results['map_table_name'] = map_table_name_tmpl.format(**results)
+        results['last_id_table_name'] = last_id_table_name_tmpl.\
+            format(**results)
+
+        # Build the statement to count how many new ID mappings are needed.
+        new_id_count_stmt = Statement(new_id_count_sql.format(**results),
+                                      new_id_count_msg.format(**results))
+
+        # Execute the new ID mapping count statement and ensure it didn't
+        # error and did return a result.
+        new_id_count_stmt.execute(conn_str)
+        check_stmt_err(new_id_count_stmt, 'ID mapping pre-transform')
+        check_stmt_data(new_id_count_stmt, 'ID mapping pre-transform')
+
+        # Get the actual count of new ID maps needed and log it.
+        results['new_id_count'] = new_id_count_stmt.data[0][0]
+        logger.info({'msg': 'counted new IDs needed', 'table': table_name,
+                     'count': results['new_id_count']})
+
+        # Build list of two last id table update statements that need to occur
+        # in a single transaction to prevent race conditions.
+        update_last_id_stmts = StatementList()
+        update_last_id_stmts.append(Statement(
+            lock_last_id_sql.format(**results),
+            lock_last_id_msg.format(**results)))
+        update_last_id_stmts.append(Statement(
+            update_last_id_sql.format(**results),
+            update_last_id_msg.format(**results)))
+
+        # Execute last id table update statements and ensure they didn't error
+        # and the second one returned results.
+        update_last_id_stmts.serial_execute(conn_str, transaction=True)
+
+        for stmt in update_last_id_stmts:
+            check_stmt_err(stmt, 'ID mapping pre-transform')
+        check_stmt_data(update_last_id_stmts[1], 'ID mapping pre-transform')
+
+        # Get the old and new last IDs from the second update statement.
+        results['old_last_id'] = update_last_id_stmts[1].data[0][0]
+        results['new_last_id'] = update_last_id_stmts[1].data[0][1]
+        logger.info({'msg': 'last ID tracking table updated',
+                     'table': table_name,
+                     'old_last})d': results['old_last_id'],
+                     'new_last_id': results['new_last_id']})
+
+        # Build statement to generate new ID maps.
+        insert_new_maps_stmt = Statement(
+            insert_new_maps_sql.format(**results),
+            insert_new_maps_msg.format(**results))
+
+        # Execute new map generation statement and ensure it didn't error.
+        insert_new_maps_stmt.execute(conn_str)
+        check_stmt_err(insert_new_maps_stmt, 'id mapping pre-transform')
+        logging.info({'msg': 'generated new ID mappings', 'table': table_name,
+                      'count': insert_new_maps_stmt.rowcount,
+                      'elapsed': secs_since(starttime)})
+
+    @classmethod
+    def modify_select(cls, metadata, table_name, select=None, join=None):
+        """Alter foreign key columns to get mapped DCC IDs.
+
+        The primary key and each foreign key which points at a data table
+        (i.e., not a vocabulary table) is altered to instead get the dcc_id's
+        from the mapping table, which requires a join to be added.
+        """
+
+        # Raise error if attempted on a vocabulary table.
+        if table_name in VOCAB_TABLES:
+            raise ValueError('ID mapping should not be performed on vocabulary'
+                             ' tables like {0}'.format(table_name))
+
+        # Get table object.
+        table = metadata.tables[table_name]
+
+        # Raise error if attempted on a multi-column primary key table.
+        if len(list(table.primary_key.columns.keys())) > 1:
+            raise ValueError('cannot map IDs for multi-column primary key'
+                             ' on table {0}'.format(table_name))
+
+        # Get primary key name and mapping table name, defined by convention.
+        pkey_name = list(table.primary_key.columns.keys())[0]
+        map_table_name = map_table_name_tmpl.format(table_name=table_name)
+
+        # Construct table object for mapping table.
+        map_table = sqlalchemy.Table(
+            map_table_name, metadata,
+            sqlalchemy.Column('dcc_id', sqlalchemy.Integer),
+            sqlalchemy.Column('site_id', sqlalchemy.Integer))
+
+        # Add a join to the mapping table.
+        if join:
+            join = join.join(map_table, table.c[pkey_name] ==
+                             map_table.c['site_id'])
+        else:
+            join = join or sqlalchemy.join(table, map_table,
+                                           table.c[pkey_name] ==
+                                           map_table.c['site_id'])
+
+        # Create a new select object, because we need to get rid of the
+        # primary key column.
+        select = select or sqlalchemy.select([table])
+        new_select = sqlalchemy.select()
+
+        # Get rid of the primary key column.
+        for c in select.inner_columns:
+            if c.name != pkey_name:
+                new_select.append_column(c)
+
+        # Add the mapping table dcc_id column as the primary key column.
+        new_select.append_column(map_table.c['dcc_id'].label(pkey_name))
+
+        # Put the new select object back in the original var for further use.
+        select = new_select
+
+        for fkey in table.foreign_key_constraints:
+
+            ref_table_name = fkey.referred_table.name
+
+            # Do not operate on foreign keys to vocabulary tables.
+            if ref_table_name in VOCAB_TABLES:
+                continue
+
+            # Get primary key name and mapping table name, defined by
+            # convention.
+            fkey_name = fkey.column_keys[0]
+            map_table_name = map_table_name_tmpl.\
+                format(table_name=ref_table_name)
+
+            # Construct table object for mapping table.
+            map_table = sqlalchemy.Table(
+                map_table_name, metadata,
+                sqlalchemy.Column('dcc_id', sqlalchemy.Integer),
+                sqlalchemy.Column('site_id', sqlalchemy.Integer))
+
+            # Make the join an outer join if the foreign key is nullable,
+            # otherwise rows without this foreign key will not be included in
+            # the final product.
+            isouter = table.c[fkey_name].nullable
+
+            # Add a join to the mapping table.
+            join = join.join(map_table, table.c[fkey_name] ==
+                             map_table.c['site_id'], isouter=isouter)
+
+            # Create a new select object, because we need to get rid of the
+            # primary key column.
+            new_select = sqlalchemy.select()
+
+            # Get rid of the primary key column.
+            for c in select.inner_columns:
+                if c.name != fkey_name:
+                    new_select.append_column(c)
+
+            # Add the mapping table dcc_id column as the primary key column.
+            new_select.append_column(map_table.c['dcc_id'].label(fkey_name))
+
+            # Put the new select object back in the original var for next use.
+            select = new_select
+
+        return select, join
+
+    @classmethod
+    def modify_table(cls, metadata, table):
+        """Helper function to apply the transformation to a table in place.
+        See Transform.modify_table for signature.
+        """
+        new_col = sqlalchemy.Column('site_id', sqlalchemy.String(32))
+        table.append_column(new_col)

--- a/pedsnetdcc/id_mapping_transform.py
+++ b/pedsnetdcc/id_mapping_transform.py
@@ -63,7 +63,7 @@ class IDMappingTransform(Transform):
             tpl_vars = {'table_name': table_name}
 
             # Error if the table has more than one primary key column.
-            if len(list(table.primary_key.columns.keys())) > 1:
+            if len(table.primary_key.columns) > 1:
                 err = ValueError('cannot generate IDs for multi-column primary'
                                  ' key on table {0}'.format(table_name))
                 logger.error({'msg': 'exiting ID mapping pre-transform',
@@ -71,7 +71,7 @@ class IDMappingTransform(Transform):
                 raise err
 
             # Error if the table has no primary key column (except death).
-            if len(list(table.primary_key.columns.keys())) == 0:
+            if len(table.primary_key.columns) == 0:
                 if table_name == 'death':
                     continue
                 err = ValueError('cannot generate IDs for table {0} with no'
@@ -156,13 +156,13 @@ class IDMappingTransform(Transform):
         table = metadata.tables[table_name]
 
         # Raise error if attempted on a multi-column primary key table.
-        if len(list(table.primary_key.columns.keys())) > 1:
+        if len(table.primary_key.columns) > 1:
             raise ValueError('cannot map IDs for multi-column primary key'
                              ' on table {0}'.format(table_name))
 
         # Skip primary key mapping if there is none (fact_relationship and pre
         # 2.3 death tables).
-        if not len(list(table.primary_key.columns.keys())) == 0:
+        if not len(table.primary_key.columns) == 0:
 
             # Get primary key name and mapping table name, defined by
             # convention.
@@ -315,12 +315,12 @@ class IDMappingTransform(Transform):
         See Transform.modify_table for signature.
         """
 
-        if len(list(table.primary_key.columns.keys())) == 1:
-            new_col = sqlalchemy.Column('site_id', sqlalchemy.String(32))
+        if len(table.primary_key.columns) == 1:
+            new_col = sqlalchemy.Column('site_id', sqlalchemy.Integer)
             table.append_column(new_col)
 
         if table.name == 'fact_relationship':
-            new_col_1 = sqlalchemy.Column('site_id_1', sqlalchemy.String(32))
-            new_col_2 = sqlalchemy.Column('site_id_2', sqlalchemy.String(32))
+            new_col_1 = sqlalchemy.Column('site_id_1', sqlalchemy.Integer)
+            new_col_2 = sqlalchemy.Column('site_id_2', sqlalchemy.Integer)
             table.append_column(new_col_1)
             table.append_column(new_col_2)

--- a/pedsnetdcc/tests/id_mapping_transform_test.py
+++ b/pedsnetdcc/tests/id_mapping_transform_test.py
@@ -1,0 +1,89 @@
+import os
+import sqlalchemy
+import sqlalchemy.dialects.postgresql
+import unittest
+
+from pedsnetdcc.id_mapping_transform import IDMappingTransform
+from pedsnetdcc.tests.transform_test_utils import clean
+from pedsnetdcc.utils import make_conn_str
+
+
+class IDMappingTransformTest(unittest.TestCase):
+
+    def setUp(self):
+        self.metadata = sqlalchemy.MetaData()
+
+        foo_id_col = sqlalchemy.Column('id', sqlalchemy.Integer,
+                                       primary_key=True)
+        bar_fk_col = sqlalchemy.Column('bar_id', sqlalchemy.Integer,
+                                       sqlalchemy.ForeignKey('bar.id'))
+        baz_fk_col = sqlalchemy.Column('baz_id', sqlalchemy.Integer,
+                                       sqlalchemy.ForeignKey('baz.id'),
+                                       nullable=False)
+        self.foo_tbl = sqlalchemy.Table('foo', self.metadata, foo_id_col,
+                                        bar_fk_col, baz_fk_col)
+
+        bar_id_col = sqlalchemy.Column('id', sqlalchemy.Integer,
+                                       primary_key=True)
+        self.bar_tbl = sqlalchemy.Table('bar', self.metadata, bar_id_col)
+
+        baz_id_col = sqlalchemy.Column('id', sqlalchemy.Integer,
+                                       primary_key=True)
+        self.baz_tbl = sqlalchemy.Table('baz', self.metadata, baz_id_col)
+
+    def test_modify_select(self):
+
+        select_obj, join_obj = IDMappingTransform.modify_select(self.metadata,
+                                                                'foo')
+
+        select_obj = select_obj.select_from(join_obj)
+
+        new_sql = str(select_obj.compile(
+            dialect=sqlalchemy.dialects.postgresql.dialect()))
+
+        # Two versions since ordering is not guaranteed.
+        expected1 = clean("""
+          SELECT foo_ids.dcc_id AS id,
+            bar_ids.dcc_id AS bar_id,
+            baz_ids.dcc_id AS baz_id
+          {NL}FROM foo
+            JOIN foo_ids ON foo.id = foo_ids.site_id
+            LEFT OUTER JOIN bar_ids ON foo.bar_id = bar_ids.site_id
+            JOIN baz_ids ON foo.baz_id = baz_ids.site_id
+          """)
+
+        expected2 = clean("""
+          SELECT foo_ids.dcc_id AS id,
+            bar_ids.dcc_id AS bar_id,
+            baz_ids.dcc_id AS baz_id
+          {NL}FROM foo
+            JOIN foo_ids ON foo.id = foo_ids.site_id
+            LEFT OUTER JOIN bar_ids ON foo.bar_id = bar_ids.site_id
+            JOIN baz_ids ON foo.baz_id = baz_ids.site_id
+          """)
+
+        self.assertTrue(new_sql == expected1 or new_sql == expected2)
+
+    def test_modify_metadata(self):
+        metadata = IDMappingTransform.modify_metadata(self.metadata)
+
+        self.assertTrue('site_id' in metadata.tables['foo'].c)
+
+    def test_pre_transform(self):
+
+        dburi_var = 'PEDSNETDCC_TEST_DBURI'
+        search_path_var = 'PEDSNETDCC_TEST_SEARCH_PATH'
+        if (dburi_var not in os.environ and
+                search_path_var not in os.environ):
+            self.skipTest(
+                '{} and {} required for testing '
+                'IDMappingTransform.pre_transform'.format(
+                    dburi_var, search_path_var))
+        conn_str = make_conn_str(uri=os.environ[dburi_var],
+                                 search_path=os.environ[search_path_var])
+        IDMappingTransform.pre_transform(conn_str, self.metadata, 'foo')
+        # TODO: verify function creation via introspection
+
+    def test_with_data(self):
+        # TODO: use test data and verify transformation results
+        self.skipTest('Not implemented yet')

--- a/pedsnetdcc/utils.py
+++ b/pedsnetdcc/utils.py
@@ -1,5 +1,7 @@
 import logging
 import re
+
+# Python 2 compatibility.
 try:
     from urllib.parse import urlparse, parse_qs
 except ImportError:

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,6 @@
 click
 dmsa
+logutils
 psycopg2
 sqlalchemy
 testing.postgresql


### PR DESCRIPTION
Some Python 2 compatibility fixes are implemented. The
Transform.pre_transform method is modified to optionally take metadata
and table_name arguments as needed by IDMappingTransform. The
IDMappingTransform.pre_transform method has not been tested since some
amount of actual data is needed to do so and the id mapping table
creation and loading functions have not yet been written. Also,
The IDMappingTransform.modify_select function is written to make the
select and join arguments optional, which I think would be good for the
other transformations too.

Signed-off-by: Aaron Browne <aaron0browne@gmail.com>