### PR TITLE
Issue 79 - Move TRANSFORMS from __init__.py to transform_runner.py

### DIFF
--- a/pedsnetdcc/__init__.py
+++ b/pedsnetdcc/__init__.py
@@ -57,13 +57,5 @@ if _dms_var in os.environ:
 else:
     DATA_MODELS_SERVICE = 'https://data-models-service.research.chop.edu/'
 
-from pedsnetdcc.age_transform import AgeTransform                   # noqa
-from pedsnetdcc.concept_name_transform import ConceptNameTransform  # noqa
-from pedsnetdcc.site_name_transform import SiteNameTransform        # noqa
-from pedsnetdcc.id_mapping_transform import IDMappingTransform      # noqa
-
-TRANSFORMS = (AgeTransform, ConceptNameTransform, SiteNameTransform,
-              IDMappingTransform)
-
-__all__ = (__version__, VOCAB_TABLES, DATA_MODELS_SERVICE, TRANSFORMS,
+__all__ = (__version__, VOCAB_TABLES, DATA_MODELS_SERVICE,
            FACT_RELATIONSHIP_DOMAINS)

--- a/pedsnetdcc/indexes.py
+++ b/pedsnetdcc/indexes.py
@@ -4,7 +4,8 @@ import time
 from psycopg2 import errorcodes as psycopg2_errorcodes
 import sqlalchemy
 
-from pedsnetdcc import VOCAB_TABLES, TRANSFORMS
+from pedsnetdcc import VOCAB_TABLES
+import pedsnetdcc.transform_runner
 from pedsnetdcc.utils import stock_metadata, get_conn_info_dict, combine_dicts
 from pedsnetdcc.dict_logging import secs_since
 from pedsnetdcc.db import Statement, StatementSet
@@ -73,7 +74,8 @@ def _indexes_sql(model_version, vocabulary=False, drop=False):
     else:
         func = sqlalchemy.schema.CreateIndex
 
-    indexes = _indexes_from_metadata(stock_metadata(model_version), TRANSFORMS,
+    indexes = _indexes_from_metadata(stock_metadata(model_version),
+                                     pedsnetdcc.transform_runner.TRANSFORMS,
                                      vocabulary=vocabulary)
     return [str(func(x).compile(
         dialect=sqlalchemy.dialects.postgresql.dialect())).lstrip()

--- a/pedsnetdcc/merge_site_data.py
+++ b/pedsnetdcc/merge_site_data.py
@@ -3,7 +3,8 @@ import time
 
 from psycopg2 import errorcodes as psycopg2_errorcodes
 
-from pedsnetdcc import VOCAB_TABLES, SITES, TRANSFORMS
+from pedsnetdcc import VOCAB_TABLES, SITES
+from pedsnetdcc.transform_runner import TRANSFORMS
 from pedsnetdcc.db import Statement, StatementSet
 from pedsnetdcc.dict_logging import secs_since
 from pedsnetdcc.foreign_keys import add_foreign_keys

--- a/pedsnetdcc/settings.py
+++ b/pedsnetdcc/settings.py
@@ -1,7 +1,0 @@
-from pedsnetdcc.age_transform import AgeTransform                   # noqa
-from pedsnetdcc.concept_name_transform import ConceptNameTransform  # noqa
-from pedsnetdcc.site_name_transform import SiteNameTransform        # noqa
-from pedsnetdcc.id_mapping_transform import IDMappingTransform      # noqa
-
-TRANSFORMS = (AgeTransform, ConceptNameTransform, SiteNameTransform,
-              IDMappingTransform)

--- a/pedsnetdcc/settings.py
+++ b/pedsnetdcc/settings.py
@@ -1,0 +1,7 @@
+from pedsnetdcc.age_transform import AgeTransform                   # noqa
+from pedsnetdcc.concept_name_transform import ConceptNameTransform  # noqa
+from pedsnetdcc.site_name_transform import SiteNameTransform        # noqa
+from pedsnetdcc.id_mapping_transform import IDMappingTransform      # noqa
+
+TRANSFORMS = (AgeTransform, ConceptNameTransform, SiteNameTransform,
+              IDMappingTransform)

--- a/pedsnetdcc/tests/foreign_keys_test.py
+++ b/pedsnetdcc/tests/foreign_keys_test.py
@@ -6,7 +6,7 @@ import testing.postgresql
 
 from pedsnetdcc.foreign_keys import (add_foreign_keys, drop_foreign_keys)
 from pedsnetdcc.utils import make_conn_str, stock_metadata
-from pedsnetdcc import TRANSFORMS
+from pedsnetdcc.transform_runner import TRANSFORMS
 from pedsnetdcc.db import Statement
 
 

--- a/pedsnetdcc/tests/indexes_test.py
+++ b/pedsnetdcc/tests/indexes_test.py
@@ -7,7 +7,7 @@ import testing.postgresql
 
 from pedsnetdcc.indexes import _indexes_sql, add_indexes, drop_indexes
 from pedsnetdcc.utils import make_conn_str, stock_metadata
-from pedsnetdcc import TRANSFORMS
+from pedsnetdcc.transform_runner import TRANSFORMS
 from pedsnetdcc.db import Statement
 
 logging.basicConfig(level=logging.DEBUG, filename="logfile")

--- a/pedsnetdcc/tests/merge_test.py
+++ b/pedsnetdcc/tests/merge_test.py
@@ -3,7 +3,8 @@ import unittest
 
 import testing.postgresql
 
-from pedsnetdcc import SITES, VOCAB_TABLES, TRANSFORMS
+from pedsnetdcc import SITES, VOCAB_TABLES
+from pedsnetdcc.transform_runner import TRANSFORMS
 from pedsnetdcc.db import Statement
 from pedsnetdcc.merge_site_data import merge_site_data, clear_dcc_data
 from pedsnetdcc.utils import make_conn_str, stock_metadata

--- a/pedsnetdcc/tests/not_nulls_test.py
+++ b/pedsnetdcc/tests/not_nulls_test.py
@@ -4,7 +4,7 @@ import sqlalchemy
 import testing.postgresql
 
 from pedsnetdcc.utils import (make_conn_str, stock_metadata)
-from pedsnetdcc import TRANSFORMS
+from pedsnetdcc.transform_runner import TRANSFORMS
 from pedsnetdcc.not_nulls import set_not_nulls, drop_not_nulls
 
 

--- a/pedsnetdcc/tests/transform_runner_test.py
+++ b/pedsnetdcc/tests/transform_runner_test.py
@@ -3,7 +3,7 @@ import unittest
 import sqlalchemy
 import testing.postgresql
 
-from pedsnetdcc import TRANSFORMS
+from pedsnetdcc.transform_runner import TRANSFORMS
 from pedsnetdcc.db import Statement
 from pedsnetdcc.schema import schema_exists
 from pedsnetdcc.transform_runner import run_transformation, undo_transformation

--- a/pedsnetdcc/transform_runner.py
+++ b/pedsnetdcc/transform_runner.py
@@ -4,7 +4,7 @@ import time
 import sqlalchemy
 import sqlalchemy.dialects.postgresql
 
-from pedsnetdcc import TRANSFORMS, VOCAB_TABLES
+from pedsnetdcc import VOCAB_TABLES
 from pedsnetdcc.db import Statement, StatementSet, StatementList
 from pedsnetdcc.dict_logging import secs_since
 from pedsnetdcc.indexes import add_indexes, drop_indexes
@@ -18,9 +18,16 @@ from pedsnetdcc.utils import (DatabaseError, get_conn_info_dict, combine_dicts,
                               stock_metadata, conn_str_with_search_path,
                               pg_error, set_logged)
 
+from pedsnetdcc.age_transform import AgeTransform
+from pedsnetdcc.concept_name_transform import ConceptNameTransform
+from pedsnetdcc.site_name_transform import SiteNameTransform
+from pedsnetdcc.id_mapping_transform import IDMappingTransform
 
 logger = logging.getLogger(__name__)
 
+
+TRANSFORMS = (AgeTransform, ConceptNameTransform, SiteNameTransform,
+              IDMappingTransform)
 
 def _transform_select_sql(model_version, site, target_schema):
     """Create SQL for `select` statement transformations.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click
+dmsa
 logutils
 psycopg2
 sqlalchemy==1.0.5
-dmsa

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,6 +1,2 @@
-click
-dmsa
-logutils
-psycopg2
-sqlalchemy
+-r requirements.txt
 testing.postgresql


### PR DESCRIPTION
To populate TRANSFORMS, the transform classes were being imported, which dragged in dependencies prematurely.  This change allows pedsnetdcc to be pip installed.  Moving all settings to a new settings.py file would be a good idea, but I'm not doing that now.  Note that indexes.py was changed slightly more than superficially needed, which was done to avoid a circular import. 