### PR TITLE
Renamed visit_start_time for v26

### DIFF
--- a/pedsnetdcc/age_transform.py
+++ b/pedsnetdcc/age_transform.py
@@ -52,7 +52,7 @@ class AgeTransform(Transform):
         'drug_exposure': ('drug_exposure_start_time',),
         'measurement': ('measurement_time', 'measurement_result_time'),
         'procedure_occurrence': ('procedure_time',),
-        'visit_occurrence': ('visit_start_time',),
+        'visit_occurrence': ('visit_start_datetime',),
         'observation': ('observation_time',),
     }
     AGE_COLUMN_TYPE = 'float'

--- a/pedsnetdcc/sync_observation_period.py
+++ b/pedsnetdcc/sync_observation_period.py
@@ -10,7 +10,7 @@ CREATE TEMP TABLE date_limit
     (person_id, table_name, min_datetime, max_datetime)
 AS
     SELECT person_id, 'visit_occurrence',
-           min(coalesce(visit_start_time, visit_start_date)),
+           min(coalesce(visit_start_datetime, visit_start_date)),
            max(coalesce(visit_end_time, visit_end_date))
     FROM visit_occurrence
     GROUP BY person_id


### PR DESCRIPTION
Changed field name from visit_start_time to visit_start_datetime in visit_occurrence table for v2.6